### PR TITLE
admin can add pickles and edit pickles

### DIFF
--- a/client/components/AddUpdatePickle.js
+++ b/client/components/AddUpdatePickle.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import {useDispatch} from 'react-redux'
+import {addNewPickle} from '../store/allPickles'
+import {updateSinglePickle} from '../store/singlePickle'
+import PickleForm from './PickleForm'
+
+const AddUpdatePickle = props => {
+  const dispatch = useDispatch()
+
+  const onSubmit = data => {
+    data.price = Number(data.price).toFixed(2) * 100
+
+    if (props.add) {
+      dispatch(addNewPickle(data))
+      props.history.push('/pickles')
+    } else {
+      dispatch(updateSinglePickle(props.pickle.id, data))
+    }
+  }
+  return <PickleForm onSubmit={onSubmit} pickle={props.pickle} />
+}
+
+export default AddUpdatePickle

--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -20,43 +20,46 @@ class Cart extends React.Component {
           </h2>
         </div>
       )
-    }
-    return (
-      <div>
-        {cart.map(item => (
-          <div key={item.pickle.id}>
-            <Link to={`/pickles/${item.pickle.id}`}> {item.pickle.title} </Link>
-            <p>Quantity: {item.qty}</p>
-            <p>Price: ${(item.pickle.price / 100).toFixed(2)} </p>
-            <button
-              type="button"
-              onClick={() => this.props.updateCart(item.pickle, -1)}
-            >
-              -
-            </button>
-            <button
-              type="button"
-              onClick={() => this.props.updateCart(item.pickle, 1)}
-            >
-              +
-            </button>
+    } else
+      return (
+        <div>
+          {cart.map(item => (
+            <div key={item.pickle.id}>
+              <Link to={`/pickles/${item.pickle.id}`}>
+                {' '}
+                {item.pickle.title}{' '}
+              </Link>
+              <p>Quantity: {item.qty}</p>
+              <p>Price: ${(item.pickle.price / 100).toFixed(2)} </p>
+              <button
+                type="button"
+                onClick={() => this.props.updateCart(item.pickle, -1)}
+              >
+                -
+              </button>
+              <button
+                type="button"
+                onClick={() => this.props.updateCart(item.pickle, 1)}
+              >
+                +
+              </button>
 
-            <button
-              type="button"
-              onClick={() => this.props.removeAll(item.pickle)}
-            >
-              x
-            </button>
-          </div>
-        ))}
-        <br />
-        Total: ${cart
-          .reduce((acc, item) => {
-            return acc + item.qty * item.price / 100
-          }, 0)
-          .toFixed(2)}
-      </div>
-    )
+              <button
+                type="button"
+                onClick={() => this.props.removeAll(item.pickle)}
+              >
+                x
+              </button>
+            </div>
+          ))}
+          <br />
+          Total: ${cart
+            .reduce((acc, item) => {
+              return acc + item.qty * item.price / 100
+            }, 0)
+            .toFixed(2)}
+        </div>
+      )
   }
 }
 

--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -34,7 +34,6 @@ class Cart extends React.Component {
             >
               -
             </button>
-
             <button
               type="button"
               onClick={() => this.props.updateCart(item.pickle, 1)}

--- a/client/components/PickleForm.js
+++ b/client/components/PickleForm.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import {useForm} from 'react-hook-form'
+
+const PickleForm = ({onSubmit, pickle}) => {
+  const {handleSubmit, register, errors} = useForm()
+
+  //setting default values for two scenarios: 1) edit, 2) add
+  const pickleForm = pickle
+    ? pickle
+    : {
+        title: '',
+        description: '',
+        price: 0,
+        inventory: 0,
+        imageUrl: '',
+        spiceLevel: '',
+        Vegetarian: true
+      }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label htmlFor="title">Title</label>
+      <input
+        type="text"
+        name="title"
+        defaultValue={pickleForm.title}
+        ref={register({required: true})}
+      />
+      {errors.title && 'This is required'}
+
+      <label htmlFor="description">Description</label>
+      <input
+        type="text"
+        name="description"
+        defaultValue={pickleForm.description}
+        ref={register({required: true})}
+      />
+      {errors.description && 'This is required'}
+
+      <label htmlFor="price">Price($)</label>
+      <input
+        type="number"
+        step="any"
+        name="price"
+        defaultValue={pickleForm.price / 100}
+        ref={register({required: true})}
+      />
+      {errors.price && 'This is required'}
+
+      <label htmlFor="inventory">Inventory</label>
+      <input
+        type="number"
+        name="inventory"
+        defaultValue={pickleForm.inventory}
+        ref={register({required: true})}
+      />
+      {errors.inventory && 'This is required'}
+
+      <label htmlFor="imageUrl">Image Url</label>
+      <input
+        type="text"
+        name="imageUrl"
+        defaultValue={pickleForm.imageUrl}
+        placeholder="select image"
+        ref={register}
+      />
+
+      <label htmlFor="spiceLevel">Spice level</label>
+      <select
+        name="spiceLevel"
+        defaultValue={pickleForm.spiceLevel}
+        ref={register({required: true})}
+      >
+        <option value="">Select...</option>
+        <option value="mild">mild</option>
+        <option value="medium">medium</option>
+        <option value="spicy">spicy</option>
+      </select>
+      {errors.spiceLevel && 'This is required'}
+
+      <label htmlFor="vegetarian">Vegetarian</label>
+      <input
+        type="checkbox"
+        name="vegetarian"
+        defaultChecked={pickleForm.vegetarian}
+        ref={register}
+      />
+
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+
+export default PickleForm

--- a/client/components/SinglePickle.js
+++ b/client/components/SinglePickle.js
@@ -2,8 +2,19 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {fetchSinglePickle} from '../store/singlePickle'
 import {updateCart} from '../store/cart'
+import {Link} from 'react-router-dom'
+import UpdatePickle from './AddUpdatePickle'
 
 class SinglePickle extends Component {
+  constructor() {
+    super()
+    this.state = {
+      toggle: false
+    }
+    this.handleClick = this.handleClick.bind(this)
+    this.toggleClick = this.toggleClick.bind(this)
+  }
+
   componentDidMount() {
     const pickleId = this.props.match.params.pickleId
     this.props.loadPickle(pickleId)
@@ -11,6 +22,10 @@ class SinglePickle extends Component {
 
   handleClick = pickle => {
     this.props.addToCart(pickle, 1)
+  }
+
+  toggleClick = () => {
+    this.setState({toggle: !this.state.toggle})
   }
 
   render() {
@@ -37,13 +52,20 @@ class SinglePickle extends Component {
               <div key={review.id}> {review.content} </div>
             ))}
         </p>
+        <br />
+        {this.props.isAdmin && (
+          <button type="button" onClick={this.toggleClick}>
+            Update this pickle
+          </button>
+        )}
+        {this.state.toggle && <UpdatePickle update={true} pickle={pickle} />}
       </div>
     )
   }
 }
 
 const mapState = state => ({
-  user: state.user,
+  isAdmin: state.user.isAdmin,
   pickle: state.singlePickle.pickle,
   loading: state.singlePickle.loading,
   error: state.singlePickle.error

--- a/client/components/SinglePickle.js
+++ b/client/components/SinglePickle.js
@@ -4,6 +4,7 @@ import {fetchSinglePickle} from '../store/singlePickle'
 import {updateCart} from '../store/cart'
 import {Link} from 'react-router-dom'
 import UpdatePickle from './AddUpdatePickle'
+import {deleteSinglePickle} from '../store/allPickles'
 
 class SinglePickle extends Component {
   constructor() {
@@ -28,6 +29,11 @@ class SinglePickle extends Component {
     this.setState({toggle: !this.state.toggle})
   }
 
+  deleteClick = () => {
+    this.props.deletePickle(this.props.pickle)
+    this.props.history.push('/pickles')
+  }
+
   render() {
     const {pickle, loading, error} = this.props
 
@@ -41,7 +47,7 @@ class SinglePickle extends Component {
         <p> Price: ${(pickle.price / 100).toFixed(2)} </p>
         <p> Spice level: {pickle.spiceLevel}</p>
         <p> Vegetarian? {pickle.vegetarian ? '✅' : '✖️'}</p>
-        <button type="button" onClick={() => this.handleClick(pickle)}>
+        <button type="button" onClick={this.handleClick}>
           {' '}
           Add to cart
         </button>
@@ -53,6 +59,11 @@ class SinglePickle extends Component {
             ))}
         </p>
         <br />
+        {this.props.isAdmin && (
+          <button type="button" onClick={this.deleteClick}>
+            Remove
+          </button>
+        )}
         {this.props.isAdmin && (
           <button type="button" onClick={this.toggleClick}>
             Update this pickle
@@ -73,7 +84,8 @@ const mapState = state => ({
 
 const mapDispatch = dispatch => ({
   loadPickle: pickleId => dispatch(fetchSinglePickle(pickleId)),
-  addToCart: (item, qty) => dispatch(updateCart(item, qty))
+  addToCart: (item, qty) => dispatch(updateCart(item, qty)),
+  deletePickle: pickle => dispatch(deleteSinglePickle(pickle))
 })
 
 export default connect(mapState, mapDispatch)(SinglePickle)

--- a/client/components/SinglePickle.js
+++ b/client/components/SinglePickle.js
@@ -14,6 +14,7 @@ class SinglePickle extends Component {
     }
     this.handleClick = this.handleClick.bind(this)
     this.toggleClick = this.toggleClick.bind(this)
+    this.deleteClick = this.deleteClick.bind(this)
   }
 
   componentDidMount() {
@@ -47,7 +48,7 @@ class SinglePickle extends Component {
         <p> Price: ${(pickle.price / 100).toFixed(2)} </p>
         <p> Spice level: {pickle.spiceLevel}</p>
         <p> Vegetarian? {pickle.vegetarian ? '✅' : '✖️'}</p>
-        <button type="button" onClick={this.handleClick}>
+        <button type="button" onClick={() => this.handleClick(pickle)}>
           {' '}
           Add to cart
         </button>

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
+import {Link} from 'react-router-dom'
 
 /**
  * COMPONENT
  */
 export const UserHome = props => {
-  const {email} = props
+  const {email, isAdmin} = props
 
   return (
     <div>
       <h3>Welcome, {email}</h3>
+      {isAdmin && <Link to="/pickles/add">Add Pickles</Link>}
     </div>
   )
 }
@@ -20,7 +22,8 @@ export const UserHome = props => {
  */
 const mapState = state => {
   return {
-    email: state.user.email
+    email: state.user.email,
+    isAdmin: state.user.isAdmin
   }
 }
 

--- a/client/routes.js
+++ b/client/routes.js
@@ -7,6 +7,7 @@ import {me} from './store'
 import AllPickles from './components/AllPickles.js'
 import SinglePickle from './components/SinglePickle.js'
 import Cart from './components/Cart.js'
+import AddPickle from './components/AddUpdatePickle'
 
 /**
  * COMPONENT
@@ -25,6 +26,11 @@ class Routes extends Component {
           <Switch>
             {/* Routes placed here are only available after logging in */}
             <Route path="/home" component={UserHome} />
+            <Route
+              exact
+              path="/pickles/add"
+              render={props => <AddPickle add={true} {...props} />}
+            />
             <Route path="/pickles/:pickleId" component={SinglePickle} />
             <Route path="/pickles" component={AllPickles} />
             <Route path="/cart" component={Cart} />

--- a/client/store/allPickles.js
+++ b/client/store/allPickles.js
@@ -50,6 +50,20 @@ export const addNewPickle = pickle => {
   }
 }
 
+export const deleteSinglePickle = pickle => {
+  return async dispatch => {
+    try {
+      dispatch(picklesLoadStart())
+      const {data} = await axios.delete(`/api/pickles/${pickle.id}`)
+      console.log(data)
+      dispatch(setPickles(data))
+    } catch (err) {
+      console.log('Something went wrong!', err)
+      dispatch(picklesLoadingError(err))
+    }
+  }
+}
+
 const allPicklesReducer = (
   allPickles = {pickles: [], loading: false, error: null},
   action

--- a/client/store/allPickles.js
+++ b/client/store/allPickles.js
@@ -55,7 +55,6 @@ export const deleteSinglePickle = pickle => {
     try {
       dispatch(picklesLoadStart())
       const {data} = await axios.delete(`/api/pickles/${pickle.id}`)
-      console.log(data)
       dispatch(setPickles(data))
     } catch (err) {
       console.log('Something went wrong!', err)

--- a/client/store/allPickles.js
+++ b/client/store/allPickles.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 const PICKLES_LOAD_START = 'PICKLES_LOAD_START'
 const SET_PICKLES = 'SET_PICKLES'
 const PICKLES_LOAD_ERROR = 'PICKLES_LOAD_ERROR'
+const ADD_PICKLE = 'ADD_PICKLE'
 
 const picklesLoadStart = () => ({
   type: PICKLES_LOAD_START
@@ -11,6 +12,11 @@ const picklesLoadStart = () => ({
 const setPickles = pickles => ({
   type: SET_PICKLES,
   pickles
+})
+
+const addPickle = pickle => ({
+  type: ADD_PICKLE,
+  pickle
 })
 
 const picklesLoadingError = err => ({
@@ -31,6 +37,19 @@ export const fetchPickles = () => {
   }
 }
 
+export const addNewPickle = pickle => {
+  return async dispatch => {
+    try {
+      dispatch(picklesLoadStart())
+      const {data} = await axios.post('/api/pickles', pickle)
+      dispatch(addPickle(data))
+    } catch (err) {
+      console.log('Something went wrong!', err)
+      dispatch(picklesLoadingError(err))
+    }
+  }
+}
+
 const allPicklesReducer = (
   allPickles = {pickles: [], loading: false, error: null},
   action
@@ -42,6 +61,8 @@ const allPicklesReducer = (
       return {...allPickles, pickles: action.pickles, loading: false}
     case PICKLES_LOAD_ERROR:
       return {...allPickles, error: action.err, loading: false}
+    case ADD_PICKLE:
+      return {...allPickles, pickles: [...allPickles.pickles, action.pickle]}
     default:
       return allPickles
   }

--- a/client/store/singlePickle.js
+++ b/client/store/singlePickle.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 const PICKLE_LOAD_START = 'PICKLE_LOAD_START'
 const SELECT_PICKLE = 'SELECT_PICKLE'
 const PICKLE_LOAD_ERROR = 'PICKLE_LOAD_ERROR'
+const UPDATE_PICKLE = 'UPDATE_PICKLE'
 
 const pickleLoadStart = () => ({
   type: PICKLE_LOAD_START
@@ -18,12 +19,30 @@ const pickleLoadingError = err => ({
   err
 })
 
+const updatePickle = pickle => ({
+  type: UPDATE_PICKLE,
+  pickle
+})
+
 export const fetchSinglePickle = pickleId => {
   return async dispatch => {
     try {
       dispatch(pickleLoadStart())
       const {data} = await axios.get(`/api/pickles/${pickleId}`)
       dispatch(selectPickle(data))
+    } catch (err) {
+      console.log('Something went wrong!', err)
+      dispatch(pickleLoadingError(err))
+    }
+  }
+}
+
+export const updateSinglePickle = (pickleId, updates) => {
+  return async dispatch => {
+    try {
+      dispatch(pickleLoadStart())
+      const {data} = await axios.put(`/api/pickles/${pickleId}`, updates)
+      dispatch(updatePickle(data))
     } catch (err) {
       console.log('Something went wrong!', err)
       dispatch(pickleLoadingError(err))
@@ -42,6 +61,12 @@ const singlePickleReducer = (
       return {...singlePickle, pickle: action.pickle, loading: false}
     case PICKLE_LOAD_ERROR:
       return {...singlePickle, error: action.err, loading: false}
+    case UPDATE_PICKLE:
+      return {
+        ...singlePickle,
+        pickle: {...singlePickle.pickle, ...action.pickle},
+        loading: false
+      }
     default:
       return singlePickle
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8203,6 +8203,11 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-hook-form": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.0.3.tgz",
+      "integrity": "sha512-6EqRWATbyXTJdtoaUDp6/2WbH9NOaPUAjsygw12nbU1yK6+x12paMJPf1eLxqT1muSvVe2G8BPqdeidqIL7bmg=="
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-hook-form": "^5.0.3",
     "react-redux": "^7.0.1",
     "react-router-dom": "^5.0.0",
     "redux": "^4.0.1",

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -4,6 +4,7 @@ module.exports = router
 router.use('/users', require('./users'))
 router.use('/pickles', require('./pickles'))
 router.use('/cart', require('./cart'))
+router.use('/orders', require('./orders'))
 
 router.use((req, res, next) => {
   const error = new Error('Not Found')

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -1,0 +1,14 @@
+const router = require('express').Router()
+const {Pickle, Review, Order, OrderItem} = require('../db/models')
+const {requireAdmin} = require('../util')
+module.exports = router
+
+//fetching all orders
+router.get('/', async (req, res, next) => {
+  try {
+    const orders = await Order.findAll({include: [OrderItem]})
+    res.json(orders)
+  } catch (err) {
+    next(err)
+  }
+})

--- a/server/api/pickles.js
+++ b/server/api/pickles.js
@@ -55,3 +55,17 @@ router.put('/:pickleId', requireAdmin, async (req, res, next) => {
     next(err)
   }
 })
+
+router.delete('/:pickleId', async (req, res, next) => {
+  try {
+    await Pickle.destroy({
+      where: {
+        id: req.params.pickleId
+      }
+    })
+    const pickles = await Pickle.findAll()
+    res.json(pickles)
+  } catch (err) {
+    next(err)
+  }
+})

--- a/server/api/pickles.js
+++ b/server/api/pickles.js
@@ -56,7 +56,7 @@ router.put('/:pickleId', requireAdmin, async (req, res, next) => {
   }
 })
 
-router.delete('/:pickleId', async (req, res, next) => {
+router.delete('/:pickleId', requireAdmin, async (req, res, next) => {
   try {
     await Pickle.destroy({
       where: {

--- a/server/api/pickles.js
+++ b/server/api/pickles.js
@@ -1,5 +1,6 @@
 const router = require('express').Router()
 const {Pickle, Review} = require('../db/models')
+const {requireAdmin} = require('../util')
 module.exports = router
 
 //fetching all pickles
@@ -19,6 +20,37 @@ router.get('/:pickleId', async (req, res, next) => {
       include: [Review]
     })
     res.json(pickle)
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/', requireAdmin, async (req, res, next) => {
+  try {
+    const pickle = await Pickle.create(req.body)
+    res.json(pickle)
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.put('/:pickleId', requireAdmin, async (req, res, next) => {
+  try {
+    const [, updaptedPickle] = await Pickle.update(req.body, {
+      where: {
+        id: req.params.pickleId
+      },
+      returning: true,
+      plain: true
+    })
+    if (updaptedPickle) {
+      const pickle = await Pickle.findByPk(req.params.pickleId, {
+        include: [{model: Review}]
+      })
+      res.json(pickle)
+    } else {
+      res.sendStatus(500)
+    }
   } catch (err) {
     next(err)
   }


### PR DESCRIPTION
Admins can now add pickles, edit existing pickles, and delete them!

Frontend:
- created 'AddUpatePickle' and 'PickleForm' components
- when updating/editing, the form populates the existing information
- used react-hook-form!
- added 'remove' button on 'SinglePickle' component (and a handle click function)
- edited 'allPickles' & 'singlePickle' redux states accordingly

Backend:
- created API for updating, adding pickle and deleting pickle

Validation:
- only Admins can edit, add & delete products: backend ('requireAdmin' util fn) and frontend ('this.props.user.isAdmin' via mapState)